### PR TITLE
ADD: Package.xml and demo_cline application metadata

### DIFF
--- a/force-app/main/default/applications/demo_cline.app-meta.xml
+++ b/force-app/main/default/applications/demo_cline.app-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+    <brand>
+        <headerColor>#0070D2</headerColor>
+        <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>
+    </brand>
+    <description>demo</description>
+    <formFactors>Small</formFactors>
+    <formFactors>Large</formFactors>
+    <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>
+    <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
+    <isNavTabPersistenceDisabled>false</isNavTabPersistenceDisabled>
+    <isOmniPinnedViewEnabled>false</isOmniPinnedViewEnabled>
+    <label>demo x Cline</label>
+    <navType>Standard</navType>
+    <uiType>Lightning</uiType>
+    <utilityBar>demo_x_Cline_UtilityBar</utilityBar>
+</CustomApplication>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>demo_cline</members>
+        <name>CustomApplication</name>
+    </types>
+    <version>62.0</version>
+</Package>


### PR DESCRIPTION
## 概要
Issue #3 の対応として、以下の変更を行いました：

1. manifest/package.xml の作成
   - CustomApplication メタデータタイプの追加
   - demo_cline アプリケーションの指定
   - API バージョン 62.0 の設定

2. demo_cline アプリケーションのメタデータ追加
   - Lightning Experience アプリケーションの設定
   - ブランド設定（ヘッダーカラー等）
   - フォームファクターの設定（Small, Large）
   - ナビゲーション設定
   - ユーティリティバーの設定

Closes #3